### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "haversine": "^1.1.1",
     "i": "^0.3.6",
     "install": "^0.12.2",
-    "npm": "^6.9.0",
     "prop-types": "^15.7.2",
     "react": "^16.5.2",
     "react-bootstrap": "^1.0.0-beta.8",


### PR DESCRIPTION

Hello jmp1234!

It seems like you have npm as one of your (dev-) dependency in runtracker.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
